### PR TITLE
Don't submit if accordion is within a form and "open/close all" is pressed

### DIFF
--- a/src/js/accordion.js
+++ b/src/js/accordion.js
@@ -64,6 +64,9 @@ Accordion.prototype.setup = function() {
 }
 
 Accordion.prototype.openOrCloseAll = function(event) {
+  // if the accordion is within a form the open/close button
+  // would submit the form
+  event.preventDefault();
 
   var open_or_close_all_button = event.target
   var now_expanded = !(open_or_close_all_button.getAttribute('aria-expanded') == 'true')


### PR DESCRIPTION
If the accordion is included in a form, the open/close button will submit the form instead of toggling. We need to prevent the default action to avoid this.