### PR TITLE
Button shouldn’t submit form

### DIFF
--- a/src/js/accordion.js
+++ b/src/js/accordion.js
@@ -54,6 +54,7 @@ Accordion.prototype.setup = function() {
   open_or_close_all_button.textContent = 'Open all'
   open_or_close_all_button.setAttribute('class', 'accordion-expand-all')
   open_or_close_all_button.setAttribute('aria-expanded', 'false')
+  open_or_close_all_button.setAttribute('type', 'button')
 
   open_or_close_all_button.addEventListener('click', this.openOrCloseAll.bind(this))
 


### PR DESCRIPTION
By setting the `<button>` type to `button`, rather than the implied default of `submit`, we can make sure that the button doesn't submit a form if the accordion is embedded within one.

Alternative fix for #3.